### PR TITLE
Add support to set the mirrorlist and metalink option in a yum repo file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# V0.7.0
+- Add support to set the mirrorlist option in a yum repo file.
+
 # V0.6.8
 - Remove pytest.ini and move its logic to pyproject.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # V0.7.0
-- Add support to set the mirrorlist option in a yum repo file.
+- Add support to set the mirrorlist and metalink options in a yum repo file.
 
 # V0.6.8
 - Remove pytest.ini and move its logic to pyproject.toml

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -20,13 +20,14 @@ entity Repository:
     """
         A yum repository.
 
-        Constraint: The baseurl and the mirrorlist attribute cannot be null at the same time.
+        Constraint: The attributes baseurl, mirrorlist and metalink cannot be null at the same time.
     """
     string name
     bool gpgcheck=false
     bool enabled=true
     string? baseurl=null
     string? mirrorlist=null
+    string? metalink=null
     string gpgkey=""
     number metadata_expire=7200
     bool skip_if_unavailable=false
@@ -36,8 +37,8 @@ std::Host.repos [0:] -- Repository.host [1]
 
 implementation validateInput for Repository:
    std::assert(
-       expression=self.baseurl != null or self.mirrorlist != null,
-       message="baseurl and mirrorlist cannot be null at the same time.",
+       expression=self.baseurl != null or self.mirrorlist != null or self.metalink != null,
+       message="baseurl, mirrorlist and metalink cannot be null at the same time.",
    )
 end
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -18,7 +18,9 @@
 
 entity Repository:
     """
-        A yum repositoy
+        A yum repository.
+
+        Constraint: The baseurl and the mirrorlist attribute cannot be null at the same time.
     """
     string name
     bool gpgcheck=false

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -23,13 +23,21 @@ entity Repository:
     string name
     bool gpgcheck=false
     bool enabled=true
-    string baseurl
+    string? baseurl=null
+    string? mirrorlist=null
     string gpgkey=""
     number metadata_expire=7200
     bool skip_if_unavailable=false
 end
 
 std::Host.repos [0:] -- Repository.host [1]
+
+implementation validateInput for Repository:
+   std::assert(
+       expression=self.baseurl != null or self.mirrorlist != null,
+       message="baseurl and mirrorlist cannot be null at the same time.",
+   )
+end
 
 implementation redhatRepo for Repository:
     repo = std::File(
@@ -43,5 +51,6 @@ implementation redhatRepo for Repository:
     )
 end
 
+implement Repository using validateInput
 implement Repository using redhatRepo when std::familyof(host.os, "redhat")
 

--- a/module.yml
+++ b/module.yml
@@ -1,4 +1,4 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: yum
-version: 0.6.11
+version: 0.7.0.dev1664874223

--- a/templates/repo.tmpl
+++ b/templates/repo.tmpl
@@ -1,9 +1,16 @@
 [{{ name }}]
 name = {{ name }}
-enabled={% if enabled %}1{%else%}0{%endif%}
-gpgcheck={% if gpgcheck %}1{%else%}0{%endif%}
+enabled={% if enabled %}1{% else %}0{% endif %}
+gpgcheck={% if gpgcheck %}1{% else %}0{% endif %}
+{% if baseurl is not none -%}
 baseurl = {{ baseurl }}
+{% endif -%}
+{% if mirrorlist is not none -%}
 mirrorlist = {{ mirrorlist }}
+{% endif -%}
+{% if metalink is not none -%}
+metalink = {{ metalink }}
+{% endif -%}
 gpgkey = {{ gpgkey }}
 metadata_expire = {{ metadata_expire }}
-skip_if_unavailable={% if skip_if_unavailable %}1{%else%}0{%endif%}
+skip_if_unavailable={% if skip_if_unavailable %}1{% else %}0{% endif %}

--- a/templates/repo.tmpl
+++ b/templates/repo.tmpl
@@ -3,6 +3,7 @@ name = {{ name }}
 enabled={% if enabled %}1{%else%}0{%endif%}
 gpgcheck={% if gpgcheck %}1{%else%}0{%endif%}
 baseurl = {{ baseurl }}
+mirrorlist = {{ mirrorlist }}
 gpgkey = {{ gpgkey }}
 metadata_expire = {{ metadata_expire }}
 skip_if_unavailable={% if skip_if_unavailable %}1{%else%}0{%endif%}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -26,8 +26,8 @@ def test_module(project: Project) -> None:
 
 def test_input_validation_on_repository(project: Project):
     """
-    Verify that an exception is raised when the baseurl and the mirrorlist of
-    a Repository is set to null.
+    Verify that an exception is raised when the baseurl, mirrorlist and metalink attributes of
+    a Repository are set to null.
     """
     with pytest.raises(CompilerException) as excinfo:
         project.compile(

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -15,8 +15,62 @@
 
     Contact: code@inmanta.com
 """
+import pytest
 from pytest_inmanta.plugin import Project
+from inmanta.ast import CompilerException
 
 
 def test_module(project: Project) -> None:
     project.compile("import yum")
+
+
+def test_input_validation_on_repository(project: Project):
+    """
+    Verify that an exception is raised when the baseurl and the mirrorlist of
+    a Repository is set to null.
+    """
+    with pytest.raises(CompilerException) as excinfo:
+        project.compile("""
+    import yum
+    yum::Repository(name="test")
+        """)
+    assert "baseurl and mirrorlist cannot be null at the same time." in str(excinfo.value)
+
+
+def test_repository(project: Project):
+    """
+    Basic test for the Repository entity.
+    """
+    project.compile("""
+import std
+import yum
+import redhat
+host= std::Host(name="localhost", os=redhat::rocky8)
+yum::Repository(
+    host=host,
+    name="test",
+    gpgcheck=true,
+    enabled=true,
+    baseurl="http://baseurl.com",
+    mirrorlist="http://mirror.com",
+    gpgkey="http://gpgkey.com",
+    metadata_expire=7200,
+    skip_if_unavailable=false,
+)
+    """)
+
+    file_instances = project.get_instances(fortype="std::File")
+    assert len(file_instances) == 1
+    expected_content_repo_file = """
+[test]
+name = test
+enabled=1
+gpgcheck=1
+baseurl = http://baseurl.com
+mirrorlist = http://mirror.com
+gpgkey = http://gpgkey.com
+metadata_expire = 7200
+skip_if_unavailable=0
+    """.strip()
+    assert file_instances[0].content.strip() == expected_content_repo_file
+    assert file_instances[0].path == "/etc/yum.repos.d/test.repo"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -85,11 +85,15 @@ gpgcheck=1
             result = f"{result}\nmirrorlist = http://mirror.com"
         if metalink:
             result = f"{result}\nmetalink = http://metalink.com"
-        return result + "\n" + """
+        return (
+            result
+            + "\n"
+            + """
 gpgkey = http://gpgkey.com
 metadata_expire = 7200
 skip_if_unavailable=0
         """.strip()
+        )
 
     file_instances = project.get_instances(fortype="std::File")
     assert len(file_instances) == 1

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -36,17 +36,23 @@ def test_input_validation_on_repository(project: Project):
     yum::Repository(name="test")
         """
         )
-    assert "baseurl and mirrorlist cannot be null at the same time." in str(
+    assert "baseurl, mirrorlist and metalink cannot be null at the same time." in str(
         excinfo.value
     )
 
 
-def test_repository(project: Project):
+@pytest.mark.parametrize("baseurl", [True, False])
+@pytest.mark.parametrize("mirrorlist", [True, False])
+@pytest.mark.parametrize("metalink", [True, False])
+def test_repository(project: Project, baseurl: bool, mirrorlist: bool, metalink: bool):
     """
     Basic test for the Repository entity.
     """
+    if not baseurl and not mirrorlist and not metalink:
+        # This combination is tested in test case: test_input_validation_on_repository
+        return
     project.compile(
-        """
+        f"""
 import std
 import yum
 import redhat
@@ -56,8 +62,9 @@ yum::Repository(
     name="test",
     gpgcheck=true,
     enabled=true,
-    baseurl="http://baseurl.com",
-    mirrorlist="http://mirror.com",
+    baseurl={"'http://baseurl.com'" if baseurl else "null"},
+    mirrorlist={"'http://mirror.com'" if mirrorlist else "null"},
+    metalink={"'http://metalink.com'" if metalink else "null"},
     gpgkey="http://gpgkey.com",
     metadata_expire=7200,
     skip_if_unavailable=false,
@@ -65,18 +72,26 @@ yum::Repository(
     """
     )
 
-    file_instances = project.get_instances(fortype="std::File")
-    assert len(file_instances) == 1
-    expected_content_repo_file = """
+    def get_expected_config_file() -> str:
+        result = """
 [test]
 name = test
 enabled=1
 gpgcheck=1
-baseurl = http://baseurl.com
-mirrorlist = http://mirror.com
+        """.strip()
+        if baseurl:
+            result = f"{result}\nbaseurl = http://baseurl.com"
+        if mirrorlist:
+            result = f"{result}\nmirrorlist = http://mirror.com"
+        if metalink:
+            result = f"{result}\nmetalink = http://metalink.com"
+        return result + "\n" + """
 gpgkey = http://gpgkey.com
 metadata_expire = 7200
 skip_if_unavailable=0
-    """.strip()
-    assert file_instances[0].content.strip() == expected_content_repo_file
+        """.strip()
+
+    file_instances = project.get_instances(fortype="std::File")
+    assert len(file_instances) == 1
+    assert file_instances[0].content.strip() == get_expected_config_file()
     assert file_instances[0].path == "/etc/yum.repos.d/test.repo"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -16,8 +16,8 @@
     Contact: code@inmanta.com
 """
 import pytest
-from pytest_inmanta.plugin import Project
 from inmanta.ast import CompilerException
+from pytest_inmanta.plugin import Project
 
 
 def test_module(project: Project) -> None:
@@ -30,18 +30,23 @@ def test_input_validation_on_repository(project: Project):
     a Repository is set to null.
     """
     with pytest.raises(CompilerException) as excinfo:
-        project.compile("""
+        project.compile(
+            """
     import yum
     yum::Repository(name="test")
-        """)
-    assert "baseurl and mirrorlist cannot be null at the same time." in str(excinfo.value)
+        """
+        )
+    assert "baseurl and mirrorlist cannot be null at the same time." in str(
+        excinfo.value
+    )
 
 
 def test_repository(project: Project):
     """
     Basic test for the Repository entity.
     """
-    project.compile("""
+    project.compile(
+        """
 import std
 import yum
 import redhat
@@ -57,7 +62,8 @@ yum::Repository(
     metadata_expire=7200,
     skip_if_unavailable=false,
 )
-    """)
+    """
+    )
 
     file_instances = project.get_instances(fortype="std::File")
     assert len(file_instances) == 1


### PR DESCRIPTION
# Description

Add support to set the mirrorlist option in a yum repo file. This change is required for a change to the infra model.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
